### PR TITLE
Add support for multiple set-cookie headers in dev-http

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject thheller/shadow-undertow "0.1.0"
+(defproject thheller/shadow-undertow "0.2.0"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
 


### PR DESCRIPTION
The current code assumes that there will be at most one set-cookie header,
which is not correct.  Applications setting more than one cookie will emit
more than one set-cookie header.  This patch switches to the undertow
header-iterator mechansim to allow more than one to pass through our
strip-secure-headers filter.

Signed-off-by: Greg Haskins <greg@manetu.com>